### PR TITLE
remove _fixed file postfix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -66,7 +66,7 @@
          level: 9
         }
        });
-       saveAs(modifiedZip, name + "_fixed.backup");
+       saveAs(modifiedZip, name + "1.backup");
        statusDiv.textContent = "Backup fixed and saved!";
       } catch (error) {
        console.error("Error modifying zip:", error);

--- a/public/index.html
+++ b/public/index.html
@@ -66,7 +66,8 @@
          level: 9
         }
        });
-       saveAs(modifiedZip, name + "1.backup");
+       const randomThreeDigitNumber = Math.floor(Math.random() * 900) + 100;
+       saveAs(modifiedZip, name + randomThreeDigitNumber + ".backup");
        statusDiv.textContent = "Backup fixed and saved!";
       } catch (error) {
        console.error("Error modifying zip:", error);


### PR DESCRIPTION
The current version of doesn't seem to accept backup files with the _fixed postfix, upon removing it it works fine, thanks for tool.
This PR just appends a '1' to the filename which worked fine for me. 